### PR TITLE
Fix truncate helper to handle undefined text

### DIFF
--- a/src/helpers/helpers.js
+++ b/src/helpers/helpers.js
@@ -177,11 +177,13 @@ const helpers = {
 		return false; // Indicate object with id not found
 	},
 
-	truncate: (text, len) => {
-		if (text.length > len)
-			return text.substring(0, len) + '...'
-		return text
-	},
+        truncate: (text, len) => {
+                if (typeof text !== 'string')
+                        return text || ''
+                if (text.length > len)
+                        return text.substring(0, len) + '...'
+                return text
+        },
 
 	intToFloat: (number) => {
 		return number.toFixed(1)

--- a/src/helpers/helpers.test.js
+++ b/src/helpers/helpers.test.js
@@ -1,0 +1,15 @@
+import { helpers } from './helpers';
+
+describe('truncate', () => {
+  test('handles undefined text', () => {
+    expect(helpers.truncate(undefined, 5)).toBe('');
+  });
+
+  test('truncates long text', () => {
+    expect(helpers.truncate('abcdef', 5)).toBe('abcde...');
+  });
+
+  test('returns original text when shorter than limit', () => {
+    expect(helpers.truncate('abc', 5)).toBe('abc');
+  });
+});


### PR DESCRIPTION
## Summary
- avoid runtime errors in `helpers.truncate` when text is undefined
- add Jest tests covering truncate behavior for undefined and long strings

## Testing
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68a3a8907e80832986a03a5d4814a4e5